### PR TITLE
chore: standardize RPC channel name

### DIFF
--- a/src/main/guard_ioc.js
+++ b/src/main/guard_ioc.js
@@ -1,4 +1,5 @@
 const { ipcMain } = require('electron');
+const RPC_CHANNEL = 'ioc:rpc';
 if (!global.__iocIpcGuardInstalled) {
   const _handle = ipcMain.handle.bind(ipcMain);
   ipcMain.handle = (channel, listener) => {
@@ -6,8 +7,8 @@ if (!global.__iocIpcGuardInstalled) {
       _handle(channel, listener);
     } catch (e) {
       const msg = String(e || '');
-      // Ignore only the duplicate-registration case for the ioc:rpc channel.
-      if (!(channel === 'ioc:rpc' && msg.includes('register a second handler'))) {
+      // Ignore only the duplicate-registration case for the RPC channel.
+      if (!(channel === RPC_CHANNEL && msg.includes('register a second handler'))) {
         throw e;
       }
     }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -48,7 +48,7 @@ async function safeRpc(method, params = [], fallback = null) {
   try { return await callCli(method, params); } catch { return fallback; }
 }
 
-ipcMain.handle('ioc/rpc', async (_e, {method, params}) => {
+ipcMain.handle('ioc:rpc', async (_e, {method, params}) => {
   return await safeRpc(method, params, null);
 });
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,6 +1,6 @@
 const {contextBridge, ipcRenderer} = require('electron');
 contextBridge.exposeInMainWorld('ioc', {
-  rpc: (method, params=[]) => ipcRenderer.invoke('ioc/rpc', {method, params}),
+  rpc: (method, params=[]) => ipcRenderer.invoke('ioc:rpc', {method, params}),
   status: () => ipcRenderer.invoke('ioc/status'),
   listAddrs: () => ipcRenderer.invoke('ioc/listaddrs'),
   listTx: (n=50) => ipcRenderer.invoke('ioc/listtx', n),

--- a/src/renderer/renderer_poll_fix.js
+++ b/src/renderer/renderer_poll_fix.js
@@ -1,15 +1,6 @@
 const { ipcRenderer } = require('electron');
 
-let last = null;
-ipcRenderer.send('subscribe:status');
-ipcRenderer.on('ioc:status', (_e, s) => {
-  last = s;
-  if (typeof window.updateFromStatus === 'function') {
-    try { window.updateFromStatus(s); } catch {}
-  }
-});
-
 window.ioc = Object.assign({}, window.ioc, {
-  status: async () => last || {},
-  rpc: (method, params=[]) => ipcRenderer.invoke('ioc:rpc', method, params)
+  status: () => ipcRenderer.invoke('ioc/status'),
+  rpc: (method, params = []) => ipcRenderer.invoke('ioc:rpc', { method, params })
 });


### PR DESCRIPTION
## Summary
- unify electron RPC channel as `ioc:rpc`
- expose status via direct invocation and drop unused subscribe channel
- guard against duplicate `ioc:rpc` handlers

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689dfffc9fcc8320867b3962d33a2629